### PR TITLE
Stubbed implementations of all desired arithmetic operators

### DIFF
--- a/arby/include/arby/arby.hpp
+++ b/arby/include/arby/arby.hpp
@@ -19,6 +19,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <compare>
 #include <limits>
 #include <string>
 #include <vector>


### PR DESCRIPTION
This defines the interface that overloaded operators for `Uint` will be implemented against