### PR TITLE
Rename arby::Uint to arby::Nat

### DIFF
--- a/arby/include/arby/Nat.hpp
+++ b/arby/include/arby/Nat.hpp
@@ -14,8 +14,8 @@
  *
  */
 
-#ifndef COM_SAXBOPHONE_ARBY_ARBY_HPP
-#define COM_SAXBOPHONE_ARBY_ARBY_HPP
+#ifndef COM_SAXBOPHONE_ARBY_NAT_HPP
+#define COM_SAXBOPHONE_ARBY_NAT_HPP
 
 #include <cmath>
 #include <cstddef>

--- a/arby/src/CMakeLists.txt
+++ b/arby/src/CMakeLists.txt
@@ -2,7 +2,7 @@
 target_sources(
     arby
         PRIVATE
-            arby.cpp
+            Nat.cpp
 )
 # sub-namespace source directories
 # NOTE: none yet!

--- a/arby/src/Nat.cpp
+++ b/arby/src/Nat.cpp
@@ -10,7 +10,7 @@
 #include <sstream>
 #include <string>
 
-#include <arby/arby.hpp>
+#include <arby/Nat.hpp>
 
 
 namespace com::saxbophone::arby {

--- a/tests/basic_arithmetic.cpp
+++ b/tests/basic_arithmetic.cpp
@@ -5,7 +5,7 @@
 
 #include <catch2/catch.hpp>
 
-#include <arby/arby.hpp>
+#include <arby/Nat.hpp>
 
 using namespace com::saxbophone;
 

--- a/tests/casting.cpp
+++ b/tests/casting.cpp
@@ -5,7 +5,7 @@
 
 #include <catch2/catch.hpp>
 
-#include <arby/arby.hpp>
+#include <arby/Nat.hpp>
 
 using namespace com::saxbophone;
 

--- a/tests/divmod.cpp
+++ b/tests/divmod.cpp
@@ -4,7 +4,7 @@
 
 #include <catch2/catch.hpp>
 
-#include <arby/arby.hpp>
+#include <arby/Nat.hpp>
 
 using namespace com::saxbophone;
 

--- a/tests/misc.cpp
+++ b/tests/misc.cpp
@@ -4,7 +4,7 @@
 
 #include <catch2/catch.hpp>
 
-#include <arby/arby.hpp>
+#include <arby/Nat.hpp>
 
 using namespace com::saxbophone;
 

--- a/tests/multiplication.cpp
+++ b/tests/multiplication.cpp
@@ -3,7 +3,7 @@
 
 #include <catch2/catch.hpp>
 
-#include <arby/arby.hpp>
+#include <arby/Nat.hpp>
 
 using namespace com::saxbophone;
 

--- a/tests/pow.cpp
+++ b/tests/pow.cpp
@@ -5,7 +5,7 @@
 
 #include <catch2/catch.hpp>
 
-#include <arby/arby.hpp>
+#include <arby/Nat.hpp>
 
 using namespace com::saxbophone;
 

--- a/tests/self_assignment.cpp
+++ b/tests/self_assignment.cpp
@@ -5,7 +5,7 @@
 
 #include <catch2/catch.hpp>
 
-#include <arby/arby.hpp>
+#include <arby/Nat.hpp>
 
 using namespace com::saxbophone;
 

--- a/tests/stringification.cpp
+++ b/tests/stringification.cpp
@@ -4,7 +4,7 @@
 
 #include <catch2/catch.hpp>
 
-#include <arby/arby.hpp>
+#include <arby/Nat.hpp>
 
 using namespace com::saxbophone;
 using namespace com::saxbophone::arby;

--- a/tests/user_defined_literals.cpp
+++ b/tests/user_defined_literals.cpp
@@ -5,7 +5,7 @@
 
 #include <catch2/catch.hpp>
 
-#include <arby/arby.hpp>
+#include <arby/Nat.hpp>
 
 using namespace com::saxbophone::arby;
 


### PR DESCRIPTION
This is named after 𝐍, the set of Natural numbers, which this type models

Closes #71