### PR TITLE
Import literals namespace into parent namespace

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -737,7 +737,7 @@ WARN_IF_DOC_ERROR      = YES
 # parameter documentation, but not about the absence of documentation.
 # The default value is: NO.
 
-WARN_NO_PARAMDOC       = YES
+WARN_NO_PARAMDOC       = NO
 
 # If the WARN_AS_ERROR tag is set to YES then doxygen will immediately stop when
 # a warning is encountered.

--- a/arby/include/arby/Nat.hpp
+++ b/arby/include/arby/Nat.hpp
@@ -32,6 +32,21 @@
 #include "codlili.hpp"
 
 
+/**
+ * @brief Main namespace
+ * @details Usage:
+ * @code{.cpp}
+ * using namespace com::saxbophone;
+ * using namespace com::saxbophone::arby::literals;
+ * @endcode
+ * - Introduces library symbols into scope `arby`
+ * - Introduces literal operators into global scope, allowing them to be used as literals
+ * @details OR:
+ * @code{.cpp}
+ * using namespace com::saxbophone::arby;
+ * @endcode
+ * - Introduces all library symbols into global scope, including literals
+ */
 namespace com::saxbophone::arby {
     namespace PRIVATE {
         /*
@@ -246,10 +261,8 @@ namespace com::saxbophone::arby {
             return this->_cast_to<long double>();
         }
         /**
-         * @brief custom ostream operator that allows this class to be printed
+         * @brief custom ostream operator that allows class Nat to be printed
          * with std::cout and friends
-         * @param os stream to output to
-         * @param object Nat to print
          */
         friend std::ostream& operator<<(std::ostream& os, const Nat& object);
         /**
@@ -653,8 +666,9 @@ namespace com::saxbophone::arby {
      * to use these literals in your code e.g. `arby::Nat f = 12345_nat`
      * This can be done without bringing the whole of arby into global scope
      * and these literals are provided in a sub-namespace for this exact reason
-     * @todo Maybe we should also import this namespace into arby's so that
-     * users get literals in global scope when they put arby into global scope
+     * @note If you introduce namespace com::saxbophone::arby into global scope,
+     * you don't need to also introduce this literals namespace --arby introduces
+     * this one automatically.
      */
     namespace literals {
         /**
@@ -664,6 +678,7 @@ namespace com::saxbophone::arby {
          * @note we use a raw literal in this case because as the Nat type is
          * unbounded, we want to support a potentially infinite number of digits,
          * or certainly more than can be stored in unsigned long long...
+         * @relatedalso com::saxbophone::arby::Nat
          */
         constexpr Nat operator "" _nat(const char* literal) {
             // detect number base
@@ -701,6 +716,9 @@ namespace com::saxbophone::arby {
             return value;
         }
     }
+
+    // introduce literals namespace into the scope of arby namespace
+    using namespace literals;
 }
 
 // adding template specialisation to std::numeric_limits<> for arby::Nat

--- a/arby/src/Nat.cpp
+++ b/arby/src/Nat.cpp
@@ -47,6 +47,9 @@ namespace com::saxbophone::arby {
         return output;
     }
 
+    /**
+     * @see std::ostream& Nat::operator<<(std::ostream& os, const Nat& object)
+     */
     std::ostream& operator<<(std::ostream& os, const Nat& object) {
         // the implementation of std::dec, std::hex and std::oct guarantees that
         // only one of them will be set in the IO stream flags if the proper

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(
         divmod.cpp
         misc.cpp
         multiplication.cpp
+        namespaces.cpp
         pow.cpp
         self_assignment.cpp
         stringification.cpp

--- a/tests/namespaces.cpp
+++ b/tests/namespaces.cpp
@@ -1,0 +1,15 @@
+#include <catch2/catch.hpp>
+
+#include <arby/Nat.hpp>
+
+TEST_CASE("Custom literals for Nat are available when namespace com::saxbophone::arby is imported", "[namespaces]") {
+    using namespace com::saxbophone::arby;
+
+    CHECK(12345678_nat == 12345678);
+}
+
+TEST_CASE("Custom literals for Nat are available when namespace com::saxbophone::arby::literals is imported", "[namespaces]") {
+    using namespace com::saxbophone::arby::literals;
+
+    CHECK(12345678_nat == 12345678);
+}


### PR DESCRIPTION
Usage:

```c++
using namespace com::saxbophone;
using namespace com::saxbophone::arby::literals;
```
- Introduces library symbols into scope `arby`
- Introduces literal operators into global scope, allowing them to be used as literals

OR:

```c++
using namespace com::saxbophone::arby;
```
- Introduces all library symbols into global scope, including literals

Closes #93