### PR TITLE
Implement bitwise operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ arby is designed with the following goals in mind:
   - All comparisons
   - cast to/from `uintmax_t` and `long double`
   - conversion to/from decimal, octal and hexadecimal string
+  - bitwise operators
 
 ### What will be provided in future?
 
 - Additions to **`Nat`**:
-  - bitwise operators
   - bit-shift operators
 - Arbitrary-precision signed integers (the [Integers](https://en.wikipedia.org/wiki/Integer)) via class **`Int`**
   - All operations supported by **`Nat`** with the exception of bitwise ones

--- a/arby/include/arby/Nat.hpp
+++ b/arby/include/arby/Nat.hpp
@@ -685,8 +685,8 @@ namespace com::saxbophone::arby {
                 } else {
                     // if the first digit, avoid pushing if zero to avoid leading zeroes
                     auto answer = *lhs_it ^ *rhs_it;
-                    if (lhs_it != lhs._digits.begin() or answer != 0) {
-                        result._digits.push_back(*lhs_it ^ *rhs_it);
+                    if (not result._digits.empty() or answer != 0) {
+                        result._digits.push_back(answer);
                     }
                     l--;
                     r--;

--- a/arby/include/arby/Nat.hpp
+++ b/arby/include/arby/Nat.hpp
@@ -661,11 +661,40 @@ namespace com::saxbophone::arby {
         }
         // bitwise XOR-assignment
         constexpr Nat& operator^=(const Nat& rhs) {
+            Nat result = *this ^ rhs; // reuse friend function
+            // re-assign digits to this
+            _digits = result._digits;
             return *this;
         }
         // bitwise XOR operator for Nat
         friend constexpr Nat operator^(Nat lhs, const Nat& rhs) {
-            return {};
+            Nat result;
+            auto lhs_it = lhs._digits.begin();
+            auto rhs_it = rhs._digits.begin();
+            std::size_t l = lhs._digits.size();
+            std::size_t r = rhs._digits.size();
+            while (lhs_it != lhs._digits.end() and rhs_it != rhs._digits.end()) {
+                if (l > r) {
+                    result._digits.push_back(*lhs_it); // XOR with zero = self
+                    l--;
+                    lhs_it++;
+                } else if (r > l) {
+                    result._digits.push_back(*rhs_it); // XOR with zero = self
+                    r--;
+                    rhs_it++;
+                } else {
+                    // if the first digit, avoid pushing if zero to avoid leading zeroes
+                    auto answer = *lhs_it ^ *rhs_it;
+                    if (lhs_it != lhs._digits.begin() or answer != 0) {
+                        result._digits.push_back(*lhs_it ^ *rhs_it);
+                    }
+                    l--;
+                    r--;
+                    lhs_it++;
+                    rhs_it++;
+                }
+            }
+            return result;
         }
         // XXX: unimplemented shift operators commented out until implemented
         // // left-shift-assignment

--- a/arby/include/arby/Nat.hpp
+++ b/arby/include/arby/Nat.hpp
@@ -600,6 +600,34 @@ namespace com::saxbophone::arby {
             std::tie(std::ignore, remainder) = Nat::divmod(lhs, rhs);
             return remainder;
         }
+        // bitwise OR-assignment
+        constexpr Nat& operator|=(const Nat& rhs) {
+            return *this;
+        }
+        // bitwise OR operator for Nat
+        friend constexpr Nat operator|(Nat lhs, const Nat& rhs) {
+            return {};
+        }
+        // bitwise AND-assignment
+        constexpr Nat& operator&=(const Nat& rhs) {
+            return *this;
+        }
+        // bitwise AND operator for Nat
+        friend constexpr Nat operator&(Nat lhs, const Nat& rhs) {
+            return {};
+        }
+        // bitwise XOR-assignment
+        constexpr Nat& operator^=(const Nat& rhs) {
+            return *this;
+        }
+        // bitwise XOR operator for Nat
+        friend constexpr Nat operator^(Nat lhs, const Nat& rhs) {
+            return {};
+        }
+        // complement operator
+        constexpr Nat operator~() {
+            return {};
+        }
         // XXX: unimplemented shift operators commented out until implemented
         // // left-shift-assignment
         // constexpr Nat& operator<<=(const Nat& n) {

--- a/arby/include/arby/Nat.hpp
+++ b/arby/include/arby/Nat.hpp
@@ -602,6 +602,23 @@ namespace com::saxbophone::arby {
         }
         // bitwise OR-assignment
         constexpr Nat& operator|=(const Nat& rhs) {
+            // add additional digits to this if fewer than rhs
+            if (_digits.size() < rhs._digits.size()) {
+                // add leading zeroes
+                _digits.push_front(rhs._digits.size(), 0);
+            }
+            auto it = _digits.begin();
+            auto rhs_it = rhs._digits.begin();
+            // if this has more digits than rhs, skip them (OR with implicit 0)
+            if (_digits.size() > rhs._digits.size()) {
+                for (std::size_t i = 0; i < _digits.size() - rhs._digits.size(); i++) {
+                    it++;
+                }
+            }
+            for (; it != _digits.end() and rhs_it != rhs._digits.end(); it++, rhs_it++) {
+                *it |= *rhs_it;
+            }
+            _trap_leading_zero();
             return *this;
         }
         // bitwise OR operator for Nat

--- a/arby/include/arby/Nat.hpp
+++ b/arby/include/arby/Nat.hpp
@@ -604,7 +604,7 @@ namespace com::saxbophone::arby {
         constexpr Nat& operator|=(const Nat& rhs) {
             // add additional digits to this if fewer than rhs
             if (_digits.size() < rhs._digits.size()) {
-                _digits.push_front(rhs._digits.size(), 0); // add leading zeroes
+                _digits.push_front(rhs._digits.size() - _digits.size(), 0); // add leading zeroes
             }
             auto it = _digits.begin();
             auto rhs_it = rhs._digits.begin();
@@ -673,7 +673,7 @@ namespace com::saxbophone::arby {
             auto rhs_it = rhs._digits.begin();
             std::size_t l = lhs._digits.size();
             std::size_t r = rhs._digits.size();
-            while (lhs_it != lhs._digits.end() and rhs_it != rhs._digits.end()) {
+            while (lhs_it != lhs._digits.end() or rhs_it != rhs._digits.end()) {
                 if (l > r) {
                     result._digits.push_back(*lhs_it); // XOR with zero = self
                     l--;
@@ -694,6 +694,7 @@ namespace com::saxbophone::arby {
                     rhs_it++;
                 }
             }
+            result._trap_leading_zero(); // XXX: should never trap, TODO: remove
             return result;
         }
         // XXX: unimplemented shift operators commented out until implemented

--- a/arby/include/arby/Nat.hpp
+++ b/arby/include/arby/Nat.hpp
@@ -600,7 +600,9 @@ namespace com::saxbophone::arby {
             std::tie(std::ignore, remainder) = Nat::divmod(lhs, rhs);
             return remainder;
         }
-        // bitwise OR-assignment
+        /**
+         * @brief bitwise OR-assignment
+         */
         constexpr Nat& operator|=(const Nat& rhs) {
             // add additional digits to this if fewer than rhs
             if (_digits.size() < rhs._digits.size()) {
@@ -620,12 +622,16 @@ namespace com::saxbophone::arby {
             _trap_leading_zero(); // XXX: should never trap, TODO: remove
             return *this;
         }
-        // bitwise OR operator for Nat
+        /**
+         * @brief bitwise OR operator for Nat
+         */
         friend constexpr Nat operator|(Nat lhs, const Nat& rhs) {
             lhs |= rhs; // reuse member operator
             return lhs;
         }
-        // bitwise AND-assignment
+        /**
+         * @brief bitwise AND-assignment
+         */
         constexpr Nat& operator&=(const Nat& rhs) {
             /*
              * if rhs has fewer digits than this, we can remove this' leading
@@ -654,19 +660,25 @@ namespace com::saxbophone::arby {
             }
             return *this;
         }
-        // bitwise AND operator for Nat
+        /**
+         * @brief bitwise AND operator for Nat
+         */
         friend constexpr Nat operator&(Nat lhs, const Nat& rhs) {
             lhs &= rhs; // reuse member operator
             return lhs;
         }
-        // bitwise XOR-assignment
+        /**
+         * @brief bitwise XOR-assignment
+         */
         constexpr Nat& operator^=(const Nat& rhs) {
             Nat result = *this ^ rhs; // reuse friend function
             // re-assign digits to this
             _digits = result._digits;
             return *this;
         }
-        // bitwise XOR operator for Nat
+        /**
+         * @brief bitwise XOR operator for Nat
+         */
         friend constexpr Nat operator^(Nat lhs, const Nat& rhs) {
             Nat result;
             auto lhs_it = lhs._digits.begin();

--- a/arby/include/arby/Nat.hpp
+++ b/arby/include/arby/Nat.hpp
@@ -624,10 +624,6 @@ namespace com::saxbophone::arby {
         friend constexpr Nat operator^(Nat lhs, const Nat& rhs) {
             return {};
         }
-        // complement operator
-        constexpr Nat operator~() {
-            return {};
-        }
         // XXX: unimplemented shift operators commented out until implemented
         // // left-shift-assignment
         // constexpr Nat& operator<<=(const Nat& n) {

--- a/arby/include/arby/Nat.hpp
+++ b/arby/include/arby/Nat.hpp
@@ -619,7 +619,6 @@ namespace com::saxbophone::arby {
             for (; it != _digits.end() and rhs_it != rhs._digits.end(); it++, rhs_it++) {
                 *it |= *rhs_it;
             }
-            _trap_leading_zero(); // XXX: should never trap, TODO: remove
             return *this;
         }
         /**
@@ -685,6 +684,7 @@ namespace com::saxbophone::arby {
             auto rhs_it = rhs._digits.begin();
             std::size_t l = lhs._digits.size();
             std::size_t r = rhs._digits.size();
+            // consume only one side when it has more unprocessed digits than the other
             while (lhs_it != lhs._digits.end() or rhs_it != rhs._digits.end()) {
                 if (l > r) {
                     result._digits.push_back(*lhs_it); // XOR with zero = self
@@ -694,9 +694,9 @@ namespace com::saxbophone::arby {
                     result._digits.push_back(*rhs_it); // XOR with zero = self
                     r--;
                     rhs_it++;
-                } else {
-                    // if the first digit, avoid pushing if zero to avoid leading zeroes
+                } else { // otherwise, consume both sides
                     auto answer = *lhs_it ^ *rhs_it;
+                    // if the first digit, avoid pushing if zero to avoid leading zeroes
                     if (not result._digits.empty() or answer != 0) {
                         result._digits.push_back(answer);
                     }
@@ -706,7 +706,6 @@ namespace com::saxbophone::arby {
                     rhs_it++;
                 }
             }
-            result._trap_leading_zero(); // XXX: should never trap, TODO: remove
             return result;
         }
         // XXX: unimplemented shift operators commented out until implemented

--- a/tests/Nat/CMakeLists.txt
+++ b/tests/Nat/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(
     Nat OBJECT
         basic_arithmetic.cpp
+        bitwise.cpp
         casting.cpp
         divmod.cpp
         misc.cpp

--- a/tests/Nat/bitwise.cpp
+++ b/tests/Nat/bitwise.cpp
@@ -20,7 +20,13 @@ TEST_CASE("arby::Nat bitwise assignment-OR", "[bitwise]") {
 }
 
 TEST_CASE("arby::Nat bitwise OR") {
-    WARN("No tests");
+    uintmax_t lhs = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    uintmax_t rhs = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    uintmax_t result = lhs | rhs;
+    arby::Nat object_lhs = lhs;
+    arby::Nat object_rhs = rhs;
+
+    CHECK((uintmax_t)(object_lhs | object_rhs) == result);
 }
 
 TEST_CASE("arby::Nat bitwise assignment-AND", "[bitwise]") {
@@ -35,9 +41,14 @@ TEST_CASE("arby::Nat bitwise assignment-AND", "[bitwise]") {
 }
 
 TEST_CASE("arby::Nat bitwise AND") {
-    WARN("No tests");
-}
+    uintmax_t lhs = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    uintmax_t rhs = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    uintmax_t result = lhs & rhs;
+    arby::Nat object_lhs = lhs;
+    arby::Nat object_rhs = rhs;
 
+    CHECK((uintmax_t)(object_lhs & object_rhs) == result);
+}
 TEST_CASE("arby::Nat bitwise assignment-XOR", "[bitwise]") {
     uintmax_t value = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
     uintmax_t other = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
@@ -50,9 +61,18 @@ TEST_CASE("arby::Nat bitwise assignment-XOR", "[bitwise]") {
 }
 
 TEST_CASE("arby::Nat bitwise XOR", "[bitwise]") {
-    WARN("No tests");
+    uintmax_t lhs = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    uintmax_t rhs = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    uintmax_t result = lhs ^ rhs;
+    arby::Nat object_lhs = lhs;
+    arby::Nat object_rhs = rhs;
+
+    CHECK((uintmax_t)(object_lhs ^ object_rhs) == result);
 }
 
 TEST_CASE("arby::Nat bitwise COMPLEMENT", "[bitwise]") {
-    WARN("No tests");
+    uintmax_t value = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    arby::Nat object = value;
+
+    CHECK((uintmax_t)(~object) == ~value);
 }

--- a/tests/Nat/bitwise.cpp
+++ b/tests/Nat/bitwise.cpp
@@ -48,6 +48,22 @@ TEST_CASE("arby::Nat bitwise OR with zero", "[bitwise]") {
     CHECK((object | 0) == object);
 }
 
+TEST_CASE("arby::Nat bitwise OR with hardcoded values", "[bitwise]") {
+    auto [lhs, rhs, expected] = GENERATE(
+        table<arby::Nat, arby::Nat, arby::Nat>(
+            {
+                {0b1101000001001010111111001, 0b00000011111111, 0b1101000001001010111111111},
+                {0x637981823345789012923acbde4184921008, 0x93f393c3e3d3a34c4c9420000, 0x63798182334d7fb93ebe3ffbfec5cdd21008},
+                {10226483191214161820, 112, 10226483191214161916}
+            }
+        )
+    );
+
+    arby::Nat result = lhs | rhs;
+
+    CHECK(result == expected);
+}
+
 TEST_CASE("arby::Nat bitwise assignment-AND", "[bitwise]") {
     uintmax_t value = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
     uintmax_t other = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
@@ -86,6 +102,22 @@ TEST_CASE("arby::Nat bitwise AND with zero", "[bitwise]") {
 
     // AND with zero should equal zero
     CHECK((object & 0) == 0);
+}
+
+TEST_CASE("arby::Nat bitwise AND with hardcoded values", "[bitwise]") {
+    auto [lhs, rhs, expected] = GENERATE(
+        table<arby::Nat, arby::Nat, arby::Nat>(
+            {
+                {0b1101000001001010111111001, 0b00000011111111, 0b11111001},
+                {0x637981823345789012923acbde4184921008, 0x93f393c3e3d3a34c4c9420000, 0x138101012380a144080020000},
+                {10226483191214161820, 112, 16}
+            }
+        )
+    );
+
+    arby::Nat result = lhs & rhs;
+
+    CHECK(result == expected);
 }
 
 TEST_CASE("arby::Nat bitwise assignment-XOR", "[bitwise]") {
@@ -127,4 +159,20 @@ TEST_CASE("arby::Nat bitwise XOR with zero", "[bitwise]") {
 
     // XOR with zero should equal self
     CHECK((object ^ 0) == object);
+}
+
+TEST_CASE("arby::Nat bitwise XOR with hardcoded values", "[bitwise]") {
+    auto [lhs, rhs, expected] = GENERATE(
+        table<arby::Nat, arby::Nat, arby::Nat>(
+            {
+                {0b1101000001001010111111001, 0b00000011111111, 0b1101000001001010100000110},
+                {0x637981823345789012923acbde4184921008, 0x93f393c3e3d3a34c4c9420000, 0x63798182334c47a92eac07f1ea854dd01008},
+                {10226483191214161820, 112, 10226483191214161900}
+            }
+        )
+    );
+
+    arby::Nat result = lhs ^ rhs;
+
+    CHECK(result == expected);
 }

--- a/tests/Nat/bitwise.cpp
+++ b/tests/Nat/bitwise.cpp
@@ -40,6 +40,14 @@ TEST_CASE("arby::Nat bitwise OR with large and small value", "[bitwise]") {
     CHECK((uintmax_t)(small_object | large_object) == result);
 }
 
+TEST_CASE("arby::Nat bitwise OR with zero", "[bitwise]") {
+    uintmax_t value = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    arby::Nat object = value;
+
+    // OR with zero should equal self
+    CHECK((object | 0) == object);
+}
+
 TEST_CASE("arby::Nat bitwise assignment-AND", "[bitwise]") {
     uintmax_t value = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
     uintmax_t other = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
@@ -70,6 +78,14 @@ TEST_CASE("arby::Nat bitwise AND with large and small value", "[bitwise]") {
 
     CHECK((uintmax_t)(large_object & small_object) == result);
     CHECK((uintmax_t)(small_object & large_object) == result);
+}
+
+TEST_CASE("arby::Nat bitwise AND with zero", "[bitwise]") {
+    uintmax_t value = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    arby::Nat object = value;
+
+    // AND with zero should equal zero
+    CHECK((object & 0) == 0);
 }
 
 TEST_CASE("arby::Nat bitwise assignment-XOR", "[bitwise]") {
@@ -103,4 +119,12 @@ TEST_CASE("arby::Nat bitwise XOR with large and small value", "[bitwise]") {
 
     CHECK((uintmax_t)(large_object ^ small_object) == result);
     CHECK((uintmax_t)(small_object ^ large_object) == result);
+}
+
+TEST_CASE("arby::Nat bitwise XOR with zero", "[bitwise]") {
+    uintmax_t value = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    arby::Nat object = value;
+
+    // XOR with zero should equal self
+    CHECK((object ^ 0) == object);
 }

--- a/tests/Nat/bitwise.cpp
+++ b/tests/Nat/bitwise.cpp
@@ -1,0 +1,58 @@
+#include <cstdint>
+
+#include <limits>
+
+#include <catch2/catch.hpp>
+
+#include <arby/Nat.hpp>
+
+using namespace com::saxbophone;
+
+TEST_CASE("arby::Nat bitwise assignment-OR", "[bitwise]") {
+    uintmax_t value = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    uintmax_t other = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    arby::Nat object = value;
+    value |= other;
+
+    object |= other;
+
+    CHECK((uintmax_t)object == value);
+}
+
+TEST_CASE("arby::Nat bitwise OR") {
+    WARN("No tests");
+}
+
+TEST_CASE("arby::Nat bitwise assignment-AND", "[bitwise]") {
+    uintmax_t value = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    uintmax_t other = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    arby::Nat object = value;
+    value &= other;
+
+    object &= other;
+
+    CHECK((uintmax_t)object == value);
+}
+
+TEST_CASE("arby::Nat bitwise AND") {
+    WARN("No tests");
+}
+
+TEST_CASE("arby::Nat bitwise assignment-XOR", "[bitwise]") {
+    uintmax_t value = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    uintmax_t other = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    arby::Nat object = value;
+    value ^= other;
+
+    object ^= other;
+
+    CHECK((uintmax_t)object == value);
+}
+
+TEST_CASE("arby::Nat bitwise XOR", "[bitwise]") {
+    WARN("No tests");
+}
+
+TEST_CASE("arby::Nat bitwise COMPLEMENT", "[bitwise]") {
+    WARN("No tests");
+}

--- a/tests/Nat/bitwise.cpp
+++ b/tests/Nat/bitwise.cpp
@@ -19,7 +19,7 @@ TEST_CASE("arby::Nat bitwise assignment-OR", "[bitwise]") {
     CHECK((uintmax_t)object == value);
 }
 
-TEST_CASE("arby::Nat bitwise OR") {
+TEST_CASE("arby::Nat bitwise OR", "[bitwise]") {
     uintmax_t lhs = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
     uintmax_t rhs = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
     uintmax_t result = lhs | rhs;
@@ -27,6 +27,17 @@ TEST_CASE("arby::Nat bitwise OR") {
     arby::Nat object_rhs = rhs;
 
     CHECK((uintmax_t)(object_lhs | object_rhs) == result);
+}
+
+TEST_CASE("arby::Nat bitwise OR with large and small value", "[bitwise]") {
+    uintmax_t large = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    uintmax_t small = GENERATE(take(200, random((uintmax_t)0, (uintmax_t)255)));
+    uintmax_t result = large | small;
+    arby::Nat large_object = large;
+    arby::Nat small_object = small;
+
+    CHECK((uintmax_t)(large_object | small_object) == result);
+    CHECK((uintmax_t)(small_object | large_object) == result);
 }
 
 TEST_CASE("arby::Nat bitwise assignment-AND", "[bitwise]") {
@@ -40,7 +51,7 @@ TEST_CASE("arby::Nat bitwise assignment-AND", "[bitwise]") {
     CHECK((uintmax_t)object == value);
 }
 
-TEST_CASE("arby::Nat bitwise AND") {
+TEST_CASE("arby::Nat bitwise AND", "[bitwise]") {
     uintmax_t lhs = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
     uintmax_t rhs = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
     uintmax_t result = lhs & rhs;
@@ -49,6 +60,18 @@ TEST_CASE("arby::Nat bitwise AND") {
 
     CHECK((uintmax_t)(object_lhs & object_rhs) == result);
 }
+
+TEST_CASE("arby::Nat bitwise AND with large and small value", "[bitwise]") {
+    uintmax_t large = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    uintmax_t small = GENERATE(take(200, random((uintmax_t)0, (uintmax_t)255)));
+    uintmax_t result = large & small;
+    arby::Nat large_object = large;
+    arby::Nat small_object = small;
+
+    CHECK((uintmax_t)(large_object & small_object) == result);
+    CHECK((uintmax_t)(small_object & large_object) == result);
+}
+
 TEST_CASE("arby::Nat bitwise assignment-XOR", "[bitwise]") {
     uintmax_t value = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
     uintmax_t other = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
@@ -69,4 +92,15 @@ TEST_CASE("arby::Nat bitwise XOR", "[bitwise]") {
     arby::Nat object_rhs = rhs;
 
     CHECK((uintmax_t)(object_lhs ^ object_rhs) == result);
+}
+
+TEST_CASE("arby::Nat bitwise XOR with large and small value", "[bitwise]") {
+    uintmax_t large = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    uintmax_t small = GENERATE(take(200, random((uintmax_t)0, (uintmax_t)255)));
+    uintmax_t result = large ^ small;
+    arby::Nat large_object = large;
+    arby::Nat small_object = small;
+
+    CHECK((uintmax_t)(large_object ^ small_object) == result);
+    CHECK((uintmax_t)(small_object ^ large_object) == result);
 }

--- a/tests/Nat/bitwise.cpp
+++ b/tests/Nat/bitwise.cpp
@@ -7,6 +7,7 @@
 #include <arby/Nat.hpp>
 
 using namespace com::saxbophone;
+using namespace com::saxbophone::arby::literals;
 
 TEST_CASE("arby::Nat bitwise assignment-OR", "[bitwise]") {
     uintmax_t value = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
@@ -52,9 +53,9 @@ TEST_CASE("arby::Nat bitwise OR with hardcoded values", "[bitwise]") {
     auto [lhs, rhs, expected] = GENERATE(
         table<arby::Nat, arby::Nat, arby::Nat>(
             {
-                {0b1101000001001010111111001, 0b00000011111111, 0b1101000001001010111111111},
-                {0x637981823345789012923acbde4184921008, 0x93f393c3e3d3a34c4c9420000, 0x63798182334d7fb93ebe3ffbfec5cdd21008},
-                {10226483191214161820, 112, 10226483191214161916}
+                {0b1101000001001010111111001_nat, 0b00000011111111_nat, 0b1101000001001010111111111_nat},
+                {0x637981823345789012923acbde4184921008_nat, 0x93f393c3e3d3a34c4c9420000_nat, 0x63798182334d7fb93ebe3ffbfec5cdd21008_nat},
+                {10226483191214161820_nat, 112_nat, 10226483191214161916_nat}
             }
         )
     );
@@ -108,9 +109,9 @@ TEST_CASE("arby::Nat bitwise AND with hardcoded values", "[bitwise]") {
     auto [lhs, rhs, expected] = GENERATE(
         table<arby::Nat, arby::Nat, arby::Nat>(
             {
-                {0b1101000001001010111111001, 0b00000011111111, 0b11111001},
-                {0x637981823345789012923acbde4184921008, 0x93f393c3e3d3a34c4c9420000, 0x138101012380a144080020000},
-                {10226483191214161820, 112, 16}
+                {0b1101000001001010111111001_nat, 0b00000011111111_nat, 0b11111001_nat},
+                {0x637981823345789012923acbde4184921008_nat, 0x93f393c3e3d3a34c4c9420000_nat, 0x138101012380a144080020000_nat},
+                {10226483191214161820_nat, 112_nat, 16_nat}
             }
         )
     );
@@ -165,9 +166,9 @@ TEST_CASE("arby::Nat bitwise XOR with hardcoded values", "[bitwise]") {
     auto [lhs, rhs, expected] = GENERATE(
         table<arby::Nat, arby::Nat, arby::Nat>(
             {
-                {0b1101000001001010111111001, 0b00000011111111, 0b1101000001001010100000110},
-                {0x637981823345789012923acbde4184921008, 0x93f393c3e3d3a34c4c9420000, 0x63798182334c47a92eac07f1ea854dd01008},
-                {10226483191214161820, 112, 10226483191214161900}
+                {0b1101000001001010111111001_nat, 0b00000011111111_nat, 0b1101000001001010100000110_nat},
+                {0x637981823345789012923acbde4184921008_nat, 0x93f393c3e3d3a34c4c9420000_nat, 0x63798182334c47a92eac07f1ea854dd01008_nat},
+                {10226483191214161820_nat, 112_nat, 10226483191214161900_nat}
             }
         )
     );

--- a/tests/Nat/bitwise.cpp
+++ b/tests/Nat/bitwise.cpp
@@ -53,10 +53,11 @@ TEST_CASE("arby::Nat bitwise assignment-XOR", "[bitwise]") {
     uintmax_t value = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
     uintmax_t other = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
     arby::Nat object = value;
+    CAPTURE(value, other);
     value ^= other;
 
     object ^= other;
-
+    CAPTURE(value, other);
     CHECK((uintmax_t)object == value);
 }
 

--- a/tests/Nat/bitwise.cpp
+++ b/tests/Nat/bitwise.cpp
@@ -69,10 +69,3 @@ TEST_CASE("arby::Nat bitwise XOR", "[bitwise]") {
 
     CHECK((uintmax_t)(object_lhs ^ object_rhs) == result);
 }
-
-TEST_CASE("arby::Nat bitwise COMPLEMENT", "[bitwise]") {
-    uintmax_t value = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
-    arby::Nat object = value;
-
-    CHECK((uintmax_t)(~object) == ~value);
-}

--- a/tests/Nat/bitwise.cpp
+++ b/tests/Nat/bitwise.cpp
@@ -9,8 +9,8 @@
 using namespace com::saxbophone;
 
 TEST_CASE("arby::Nat bitwise assignment-OR", "[bitwise]") {
-    uintmax_t value = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
-    uintmax_t other = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    uintmax_t value = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    uintmax_t other = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
     arby::Nat object = value;
     value |= other;
 
@@ -20,8 +20,8 @@ TEST_CASE("arby::Nat bitwise assignment-OR", "[bitwise]") {
 }
 
 TEST_CASE("arby::Nat bitwise OR") {
-    uintmax_t lhs = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
-    uintmax_t rhs = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    uintmax_t lhs = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    uintmax_t rhs = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
     uintmax_t result = lhs | rhs;
     arby::Nat object_lhs = lhs;
     arby::Nat object_rhs = rhs;
@@ -30,8 +30,8 @@ TEST_CASE("arby::Nat bitwise OR") {
 }
 
 TEST_CASE("arby::Nat bitwise assignment-AND", "[bitwise]") {
-    uintmax_t value = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
-    uintmax_t other = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    uintmax_t value = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    uintmax_t other = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
     arby::Nat object = value;
     value &= other;
 
@@ -41,8 +41,8 @@ TEST_CASE("arby::Nat bitwise assignment-AND", "[bitwise]") {
 }
 
 TEST_CASE("arby::Nat bitwise AND") {
-    uintmax_t lhs = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
-    uintmax_t rhs = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    uintmax_t lhs = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    uintmax_t rhs = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
     uintmax_t result = lhs & rhs;
     arby::Nat object_lhs = lhs;
     arby::Nat object_rhs = rhs;
@@ -50,8 +50,8 @@ TEST_CASE("arby::Nat bitwise AND") {
     CHECK((uintmax_t)(object_lhs & object_rhs) == result);
 }
 TEST_CASE("arby::Nat bitwise assignment-XOR", "[bitwise]") {
-    uintmax_t value = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
-    uintmax_t other = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    uintmax_t value = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    uintmax_t other = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
     arby::Nat object = value;
     value ^= other;
 
@@ -61,8 +61,8 @@ TEST_CASE("arby::Nat bitwise assignment-XOR", "[bitwise]") {
 }
 
 TEST_CASE("arby::Nat bitwise XOR", "[bitwise]") {
-    uintmax_t lhs = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
-    uintmax_t rhs = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    uintmax_t lhs = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
+    uintmax_t rhs = GENERATE(take(200, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
     uintmax_t result = lhs ^ rhs;
     arby::Nat object_lhs = lhs;
     arby::Nat object_rhs = rhs;


### PR DESCRIPTION
- [x] Add additional test cases for bitwise operations with large and small values on lhs/rhs
- [x] Add additional test cases for bitwise operations with zero
- [x] Add additional test cases for bitwise operations on sets of hardcoded values
- [x] Remove redundant trailing zero trap
- [x] Document new functions
- [x] Update README

Closes #44