### PR TITLE
Query size of Nat object

### DIFF
--- a/arby/include/arby/Nat.hpp
+++ b/arby/include/arby/Nat.hpp
@@ -812,7 +812,7 @@ namespace com::saxbophone::arby {
         }
         // get size by number of digits
         constexpr std::size_t digit_length() const {
-            return {};
+            return _digits.size();
         }
         // get size by number of bytes needed to store the number's digits
         constexpr std::size_t byte_length() const {

--- a/arby/include/arby/Nat.hpp
+++ b/arby/include/arby/Nat.hpp
@@ -816,7 +816,12 @@ namespace com::saxbophone::arby {
         }
         // get size by number of bytes needed to store the number's digits
         constexpr std::size_t byte_length() const {
-            return {};
+            // this is how many bytes are needed to store the digits
+            std::size_t bytes_for_digits = _digits.size() * sizeof(StorageType);
+            // reduce size if leading digit is not full occupancy
+            std::size_t leading_occupancy = PRIVATE::fit(_digits.front(), 256);
+            bytes_for_digits -= (sizeof(StorageType) - leading_occupancy);
+            return bytes_for_digits;
         }
         // get size by number of bits needed to store the number's value
         // NOTE: this can be less than byte_length() * 8

--- a/arby/include/arby/Nat.hpp
+++ b/arby/include/arby/Nat.hpp
@@ -826,7 +826,12 @@ namespace com::saxbophone::arby {
         // get size by number of bits needed to store the number's value
         // NOTE: this can be less than byte_length() * 8
         constexpr std::size_t bit_length() const {
-            return {};
+            // this is how many bits are needed to store the digits
+            std::size_t bits_for_digits = _digits.size() * sizeof(StorageType) * 8;
+            // reduce size if leading digit is not full occupancy
+            std::size_t leading_occupancy = PRIVATE::fit(_digits.front(), 2);
+            bits_for_digits -= (sizeof(StorageType) * 8 - leading_occupancy);
+            return bits_for_digits;
         }
     private:
         std::string _stringify_for_base(std::uint8_t base) const;

--- a/arby/include/arby/Nat.hpp
+++ b/arby/include/arby/Nat.hpp
@@ -810,11 +810,16 @@ namespace com::saxbophone::arby {
             // zero is false --all other values are true
             return _digits.front() != 0; // assuming no leading zeroes
         }
-        // get size by number of digits
+        /**
+         * @returns size by number of digits
+         */
         constexpr std::size_t digit_length() const {
             return _digits.size();
         }
-        // get size by number of bytes needed to store the number's digits
+        /**
+         * @returns size by number of bytes needed to store the number's digits
+         * @note this can be less than \f$ digits \times sizeof(digit) \f$
+         */
         constexpr std::size_t byte_length() const {
             // this is how many bytes are needed to store the digits
             std::size_t bytes_for_digits = _digits.size() * sizeof(StorageType);
@@ -823,8 +828,10 @@ namespace com::saxbophone::arby {
             bytes_for_digits -= (sizeof(StorageType) - leading_occupancy);
             return bytes_for_digits;
         }
-        // get size by number of bits needed to store the number's value
-        // NOTE: this can be less than byte_length() * 8
+        /**
+         * @returns size by number of bits needed to store the number's value
+         * @note this can be less than \f$ bytes \times 8 \f$
+         */
         constexpr std::size_t bit_length() const {
             // this is how many bits are needed to store the digits
             std::size_t bits_for_digits = _digits.size() * sizeof(StorageType) * 8;

--- a/arby/include/arby/Nat.hpp
+++ b/arby/include/arby/Nat.hpp
@@ -810,6 +810,19 @@ namespace com::saxbophone::arby {
             // zero is false --all other values are true
             return _digits.front() != 0; // assuming no leading zeroes
         }
+        // get size by number of digits
+        constexpr std::size_t digit_length() const {
+            return {};
+        }
+        // get size by number of bytes needed to store the number's digits
+        constexpr std::size_t byte_length() const {
+            return {};
+        }
+        // get size by number of bits needed to store the number's value
+        // NOTE: this can be less than byte_length() * 8
+        constexpr std::size_t bit_length() const {
+            return {};
+        }
     private:
         std::string _stringify_for_base(std::uint8_t base) const;
 

--- a/tests/Nat/CMakeLists.txt
+++ b/tests/Nat/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(
         misc.cpp
         multiplication.cpp
         namespaces.cpp
+        query_size.cpp
         self_assignment.cpp
         stringification.cpp
         user_defined_literals.cpp

--- a/tests/Nat/query_size.cpp
+++ b/tests/Nat/query_size.cpp
@@ -1,0 +1,30 @@
+#include <catch2/catch.hpp>
+
+#include <arby/Nat.hpp>
+#include <arby/math.hpp>
+
+using namespace com::saxbophone;
+
+TEST_CASE("arby::Nat.digit_length() returns the number of digits used to store the value", "[query-size]") {
+    auto digits = GENERATE(range(1u, 10u));
+
+    arby::Nat value = arby::pow(arby::Nat::BASE, digits - 1);
+
+    CHECK(value.digit_length() == digits);
+}
+
+TEST_CASE("arby::Nat.byte_length() returns the number of bytes needed to store the value", "[query-size]") {
+    auto digits = GENERATE(range(1u, 10u));
+
+    arby::Nat value = arby::pow(256, digits - 1);
+
+    CHECK(value.byte_length() == digits);
+}
+
+TEST_CASE("arby::Nat.bit_length() returns the number of bits needed to store the value", "[query-size]") {
+    auto digits = GENERATE(range(1u, 100u));
+
+    arby::Nat value = arby::pow(2, digits - 1);
+
+    CHECK(value.bit_length() == digits);
+}


### PR DESCRIPTION
NOTE: this implementation assumes that `CHAR_BIT` is always $8$ (i.e. our bytes are always 8-bit). This is true on all but the most obscure systems, on which it might break without warning, or fail silently (or not fail but give incorrect behaviour, silently).

Closes #84