### PR TITLE
Initial reimplementation of storage type selection:

### DIFF
--- a/arby/include/arby/Nat.hpp
+++ b/arby/include/arby/Nat.hpp
@@ -73,11 +73,11 @@ namespace com::saxbophone::arby {
         };
         template <typename T> requires (not std::numeric_limits<T>::is_signed)
         struct GetNextBiggerType {
-            using Type = GetTypeForSize<std::numeric_limits<T>::digits * 2>::Type;
+            using Type = typename GetTypeForSize<std::numeric_limits<T>::digits * 2>::Type;
         };
         template <typename T> requires (not std::numeric_limits<T>::is_signed)
         struct GetNextSmallerType {
-            using Type = GetTypeForSize<std::numeric_limits<T>::digits / 2>::Type;
+            using Type = typename GetTypeForSize<std::numeric_limits<T>::digits / 2>::Type;
         };
 
         struct StorageTraits {

--- a/arby/include/arby/Nat.hpp
+++ b/arby/include/arby/Nat.hpp
@@ -128,7 +128,17 @@ namespace com::saxbophone::arby {
     class Nat {
     private:
         using StorageType = PRIVATE::StorageTraits::StorageType;
+    public:
+        /**
+         * @brief This is the smallest type guaranteed to be able to store the
+         * result of any product or sum of two values of the type used to store
+         * the number's digits.
+         * @note Consequently, this is the type used to represent Nat::BASE as
+         * that value is +1 beyond the upper bound for the type used to store
+         * the digits.
+         */
         using OverflowType = PRIVATE::StorageTraits::OverflowType;
+    private:
         static constexpr std::size_t BITS_BETWEEN = std::numeric_limits<OverflowType>::digits - std::numeric_limits<StorageType>::digits;
         // validates the digits array
         constexpr void _validate_digits() const {

--- a/tests/Nat/basic_arithmetic.cpp
+++ b/tests/Nat/basic_arithmetic.cpp
@@ -26,8 +26,7 @@ TEST_CASE("std::numeric_limits<arby::Nat>", "[numeric-limits]") {
     CHECK(std::numeric_limits<arby::Nat>::digits == 0); // N/A
     CHECK(std::numeric_limits<arby::Nat>::digits10 == 0); // N/A
     CHECK(std::numeric_limits<arby::Nat>::max_digits10 == 0); // N/A
-    // calculate the bit width of the next-lowest type, its place value is the radix
-    CHECK(std::numeric_limits<arby::Nat>::radix == 1u << ((std::numeric_limits<int>::digits + 1) / 2));
+    CHECK(std::numeric_limits<arby::Nat>::radix == 2);
     CHECK(std::numeric_limits<arby::Nat>::min_exponent == 0); // N/A
     CHECK(std::numeric_limits<arby::Nat>::min_exponent10 == 0); // N/A
     CHECK(std::numeric_limits<arby::Nat>::max_exponent == 0); // N/A


### PR DESCRIPTION
- now picks unsigned int by default, only chooses next-smallest unsigned int if unsigned int is same size as uintmax_t for some reason (unlikely but possible?)
- Nat::BASE is now of type OverflowType (I think we forgot to make that type public...)
- std::numeric_limits<Nat>::radix no longer gives BASE (it will overflow int, which is the type that radix is required to be), instead just returns 2

Closes #111