### PR TITLE
Optimise log for binary bases and lesser optimise for generic bases

### DIFF
--- a/arby/include/arby/Nat.hpp
+++ b/arby/include/arby/Nat.hpp
@@ -1063,12 +1063,17 @@ namespace com::saxbophone::arby {
         // if base is 2, count the bits instead
         if (base == 2) {
             auto count = x.bit_length();
-            // just determine if x fully uses all the bits or not
-            if ((Nat(1) << count - 1) == x) {
+            if (x.is_power_of_2()) {
                 return {count - 1}; // 1 followed by count-1 many zeroes
             } else {
                 return {count - 1, count};
             }
+        }
+        // if base is a power of 2, we can count how many n-bit chunks there are
+        if (base.is_power_of_2()) {
+            auto b = ilog(2, base).floor;
+            auto xl = ilog(2, x);
+            return {xl.floor / b, xl.ceil / b + (xl.ceil % b > 0)};
         }
         // find the smallest power of base that is just >= than x
         Nat power = 1;

--- a/arby/include/arby/Nat.hpp
+++ b/arby/include/arby/Nat.hpp
@@ -1060,7 +1060,7 @@ namespace com::saxbophone::arby {
     constexpr Interval<uintmax_t> ilog(const Nat& base, const Nat& x) {
         if (base < 2) { throw std::domain_error("ilog: base cannot be < 2"); }
         if (x < 1) { throw std::domain_error("ilog: x cannot be < 1"); }
-        // if base is 2, count the bits instead
+        // if base is 2, count the bits
         if (base == 2) {
             auto count = x.bit_length();
             if (x.is_power_of_2()) {
@@ -1069,17 +1069,16 @@ namespace com::saxbophone::arby {
                 return {count - 1, count};
             }
         }
-        // if base is a power of 2, we can count how many n-bit chunks there are
+        // if base is any other power of 2, we can count how many n-bit chunks there are
         if (base.is_power_of_2()) {
             auto b = ilog(2, base).floor; // floor=ceil in this case, as base is binary power
             auto xl = ilog(2, x); // log₂(x)
             // floor-rounding the floor and ceil-rounding the ceil divided by b gives an accurate answer
             return {xl.floor / b, xl.ceil / b + (xl.ceil % b > 0)};
         }
-        // find the smallest power of base that is just >= than x
+        // otherwise, find the smallest power of base that is just >= x
         // a good starting estimate can be found using log₂ of both base and x
-        uintmax_t exponent = ilog(2, x).floor / ilog(2, base).ceil; // deliberate underestimate
-        // NOTE: if binary search is desired rather than linear search from minimum bound, calculate an exponent interval
+        uintmax_t exponent = ilog(2, x).floor / ilog(2, base).ceil; // deliberate underestimate, but closer than 1
         Nat power = ipow(base, exponent);
         uintmax_t floor = exponent;
         while (power < x) {

--- a/arby/include/arby/Nat.hpp
+++ b/arby/include/arby/Nat.hpp
@@ -1077,9 +1077,11 @@ namespace com::saxbophone::arby {
             return {xl.floor / b, xl.ceil / b + (xl.ceil % b > 0)};
         }
         // find the smallest power of base that is just >= than x
-        Nat power = 1;
-        uintmax_t floor = 0;
-        uintmax_t exponent = 0;
+        // a good starting estimate can be found using log₂ of both base and x
+        uintmax_t exponent = ilog(2, x).floor / ilog(2, base).ceil; // deliberate underestimate
+        // NOTE: if binary search is desired rather than linear search from minimum bound, calculate an exponent interval
+        Nat power = ipow(base, exponent);
+        uintmax_t floor = exponent;
         while (power < x) {
             power *= base;
             floor = exponent++; // increment and store old value in floor

--- a/arby/include/arby/Nat.hpp
+++ b/arby/include/arby/Nat.hpp
@@ -1071,8 +1071,9 @@ namespace com::saxbophone::arby {
         }
         // if base is a power of 2, we can count how many n-bit chunks there are
         if (base.is_power_of_2()) {
-            auto b = ilog(2, base).floor;
-            auto xl = ilog(2, x);
+            auto b = ilog(2, base).floor; // floor=ceil in this case, as base is binary power
+            auto xl = ilog(2, x); // log₂(x)
+            // floor-rounding the floor and ceil-rounding the ceil divided by b gives an accurate answer
             return {xl.floor / b, xl.ceil / b + (xl.ceil % b > 0)};
         }
         // find the smallest power of base that is just >= than x

--- a/tests/Nat/ilog.cpp
+++ b/tests/Nat/ilog.cpp
@@ -83,12 +83,14 @@ TEST_CASE("arby::ilog() with hardcoded values", "[math-support][ilog]") {
 // regression tests for log with power of 2 base, because these is special-cased for performance reasons
 TEST_CASE("arby::ilog(2**i, x) regression test", "[math-support][ilog]") {
     uintmax_t x = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
-    uintmax_t i = GENERATE((uintmax_t)1, std::numeric_limits<uintmax_t>::digits / 2);
+    uintmax_t i = GENERATE((uintmax_t)1, std::numeric_limits<uintmax_t>::digits);
     auto power = std::pow(2, i);
     auto real_log = std::log(x) / std::log(power);
     arby::Interval<uintmax_t> expected((uintmax_t)std::floor(real_log), (uintmax_t)std::ceil(real_log));
 
     auto result = arby::ilog(arby::ipow(2, i), x);
+
+    CAPTURE(x, i, power, real_log, expected.floor, expected.ceil, result.floor, result.ceil);
 
     CHECK(result == expected);
 }

--- a/tests/Nat/ilog.cpp
+++ b/tests/Nat/ilog.cpp
@@ -80,13 +80,15 @@ TEST_CASE("arby::ilog() with hardcoded values", "[math-support][ilog]") {
     CHECK(result_ceil == expected_ceil);
 }
 
-// regression tests for base-2 log, because this is special-cased for performance reasons
-TEST_CASE("arby::ilog(2, x) regression test", "[math-support][ilog]") {
+// regression tests for log with power of 2 base, because these is special-cased for performance reasons
+TEST_CASE("arby::ilog(2**i, x) regression test", "[math-support][ilog]") {
     uintmax_t x = GENERATE(take(100, random((uintmax_t)0, std::numeric_limits<uintmax_t>::max())));
-    auto real_log = std::log2(x);
+    uintmax_t i = GENERATE((uintmax_t)1, std::numeric_limits<uintmax_t>::digits / 2);
+    auto power = std::pow(2, i);
+    auto real_log = std::log(x) / std::log(power);
     arby::Interval<uintmax_t> expected((uintmax_t)std::floor(real_log), (uintmax_t)std::ceil(real_log));
 
-    auto result = arby::ilog(2, x);
+    auto result = arby::ilog(arby::ipow(2, i), x);
 
     CHECK(result == expected);
 }


### PR DESCRIPTION
- For bases which are powers of 2, we now use a derivative of the bit-counting technique to generate fast results (we basically count the number of N-bit-sized "chunks" that exist in the bitstring of $x$
- For other bases, we simply derive a deliberate underestimate of the true $log$ using $floor(log_2(x) / log_2(b))$ and start iterating exponentiation from _here_ rather than from 1. It's debatable whether using binary search between the min and max bounds of this would be faster or not, however I am deciding not to include it because multiplication is cheaper than division and exponentiation in this library, and the remaining linear search required is likely to not be that large...

Closes #124