### PR TITLE
Cool, tried out using a CMake module which adds sanitisers for you

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,6 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         cxx: [g++-10, clang++]
-        memcheck: [false]
         include:
           # macos has two separate versions for the different compilers because
           # the new macos image needed for clang using a new version of XCode
@@ -38,27 +37,17 @@ jobs:
             cxx: clang++
           - os: windows-2019
             cxx: msvc
-          - os: ubuntu-20.04
-            cxx: g++-10
-            memcheck: true # memory-testing on Linux only
 
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: true
 
-
       # when building on master branch and not a pull request, build and test in release mode (optimised build)
       - name: Set Build Mode to Release
         shell: bash
         if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/master' }}
         run: echo "BUILD_TYPE=Release" >> $GITHUB_ENV
-
-      - name: Install Valgrind
-        if: ${{ matrix.memcheck }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install valgrind
 
       - name: Configure CMake
         env:
@@ -79,21 +68,11 @@ jobs:
         run: cmake --build . --config $BUILD_TYPE
 
       - name: Test
-        if: ${{ !matrix.memcheck }}
         working-directory: ${{github.workspace}}/build
         shell: bash
         # Execute tests defined by the CMake configuration.  
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
         run: ctest -C $BUILD_TYPE --no-tests=error
-
-      - name: Test with Valgrind
-        if: ${{ matrix.memcheck }}
-        working-directory: ${{github.workspace}}/build
-        shell: bash
-        # run ctest with memcheck mode to check for memory errors with Valgrind
-        # exclude the one test case for arby::Nat::from_float with NaN/Inf because it fails on Valgrind
-        # due to lack of long double support
-        run: ctest -C $BUILD_TYPE -T memcheck -j3 -E "with non-finite value throws" --no-tests=error
 
       - name: Test Install
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -43,7 +43,10 @@ jobs:
             memcheck: true # memory-testing on Linux only
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
 
       # when building on master branch and not a pull request, build and test in release mode (optimised build)
       - name: Set Build Mode to Release

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cmake/Modules/externals/sanitizers-cmake"]
+	path = cmake/Modules/externals/sanitizers-cmake
+	url = git@github.com:arsenm/sanitizers-cmake.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ else() # GCC/Clang warning option
     enable_cxx_compiler_flag_if_supported("-Wno-unknown-pragmas")
     # if tests are enabled, enable converting all warnings to errors too
     if (ENABLE_TESTS)
-        enable_cxx_compiler_flag_if_supported("-Werror")
+        # enable_cxx_compiler_flag_if_supported("-Werror")
         # exclude the following kinds of warnings from being converted into errors
         # unknown-pragma is useful to have as a warning but not as an error, if you have
         # pragmas which are for the consumption of one compiler only
@@ -128,6 +128,8 @@ else() # GCC/Clang warning option
         enable_cxx_compiler_flag_if_supported("-Wno-error=unused-but-set-variable")
         # Clang's now introduced a "helpful" analysis of for-loops that increment a variable twice
         enable_cxx_compiler_flag_if_supported("-Wno-error=for-loop-analysis")
+        # XXX: make sanitizer force quit
+        # enable_cxx_compiler_flag_if_supported("-fno-sanitize-recover=all")
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,7 @@ endif()
 
 # add custom dependencies directory
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/externals/sanitizers-cmake/cmake")
 
 # a better way to load dependencies
 include(CPM)

--- a/arby/include/arby/Nat.hpp
+++ b/arby/include/arby/Nat.hpp
@@ -213,6 +213,8 @@ namespace com::saxbophone::arby {
          */
         constexpr Nat() : _digits{0} {
             _validate_digits();
+            int k = 0x7fffffff;
+            k += 1; // cause integer overflow
         }
         /**
          * @brief Integer-constructor, initialises with the given integer value

--- a/arby/include/arby/Nat.hpp
+++ b/arby/include/arby/Nat.hpp
@@ -213,8 +213,8 @@ namespace com::saxbophone::arby {
          */
         constexpr Nat() : _digits{0} {
             _validate_digits();
-            int k = 0x7fffffff;
-            k += 1; // cause integer overflow
+            int i = std::numeric_limits<int>::max();
+            ++i;
         }
         /**
          * @brief Integer-constructor, initialises with the given integer value

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,11 @@ CPMFindPackage(
     EXCLUDE_FROM_ALL YES
 )
 
+set(SANITIZE_ADDRESS ON)
+set(SANITIZE_UNDEFINED ON)
+
+find_package(Sanitizers)
+
 # common option-propagating target to use for test suite sub-targets
 add_library(tests-config INTERFACE)
 target_link_libraries(
@@ -35,6 +40,7 @@ target_link_libraries(
         arby
         Catch2::Catch2  # unit testing framework
 )
+add_sanitizers(tests)
 
 enable_testing()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,9 @@ target_link_libraries(
         arby
         Catch2::Catch2  # unit testing framework
 )
+if (NOT MSVC) # Sanitizers package doesn't seem to work well with MSVC on CI...
+    add_sanitizers(tests-config)
+endif()
 
 # every sub-part of the test suite
 add_subdirectory(DivisionResult)
@@ -42,9 +45,6 @@ target_link_libraries(
         arby
         Catch2::Catch2  # unit testing framework
 )
-if (NOT MSVC) # Sanitizers package doesn't seem to work well with MSVC on CI...
-    add_sanitizers(tests)
-endif()
 
 enable_testing()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,10 +5,12 @@ CPMFindPackage(
     EXCLUDE_FROM_ALL YES
 )
 
-set(SANITIZE_ADDRESS ON)
-set(SANITIZE_UNDEFINED ON)
+if (NOT MSVC) # Sanitizers package doesn't seem to work well with MSVC on CI...
+    set(SANITIZE_ADDRESS ON)
+    set(SANITIZE_UNDEFINED ON)
 
-find_package(Sanitizers)
+    find_package(Sanitizers)
+endif()
 
 # common option-propagating target to use for test suite sub-targets
 add_library(tests-config INTERFACE)
@@ -40,7 +42,9 @@ target_link_libraries(
         arby
         Catch2::Catch2  # unit testing framework
 )
-add_sanitizers(tests)
+if (NOT MSVC) # Sanitizers package doesn't seem to work well with MSVC on CI...
+    add_sanitizers(tests)
+endif()
 
 enable_testing()
 

--- a/tests/DivisionResult/CMakeLists.txt
+++ b/tests/DivisionResult/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library(DivisionResult OBJECT division_result.cpp)
 target_link_libraries(DivisionResult PRIVATE tests-config)
-target_precompile_headers(DivisionResult PRIVATE <arby/DivisionResult.hpp> <arby/Interval.hpp> <arby/Nat.hpp>)
+# target_precompile_headers(DivisionResult PRIVATE <arby/DivisionResult.hpp> <arby/Interval.hpp> <arby/Nat.hpp>)

--- a/tests/Interval/CMakeLists.txt
+++ b/tests/Interval/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library(Interval OBJECT interval.cpp)
 target_link_libraries(Interval PRIVATE tests-config)
-target_precompile_headers(Interval PRIVATE <arby/Interval.hpp> <arby/Nat.hpp>)
+# target_precompile_headers(Interval PRIVATE <arby/Interval.hpp> <arby/Nat.hpp>)

--- a/tests/Nat/CMakeLists.txt
+++ b/tests/Nat/CMakeLists.txt
@@ -17,5 +17,6 @@ add_library(
         stringification.cpp
         user_defined_literals.cpp
 )
+add_sanitizers(Nat)
 target_link_libraries(Nat PRIVATE tests-config)
 # target_precompile_headers(Nat PRIVATE <arby/DivisionResult.hpp> <arby/Interval.hpp> <arby/Nat.hpp>)

--- a/tests/Nat/CMakeLists.txt
+++ b/tests/Nat/CMakeLists.txt
@@ -18,4 +18,4 @@ add_library(
         user_defined_literals.cpp
 )
 target_link_libraries(Nat PRIVATE tests-config)
-target_precompile_headers(Nat PRIVATE <arby/DivisionResult.hpp> <arby/Interval.hpp> <arby/Nat.hpp>)
+# target_precompile_headers(Nat PRIVATE <arby/DivisionResult.hpp> <arby/Interval.hpp> <arby/Nat.hpp>)


### PR DESCRIPTION
I'll see if this works on Github-actions before making it CI-only. I think we do want it only on CI because it's noticeably slower than normal (but still *MUCH* faster than Valgrind!)